### PR TITLE
refactor: create new `TaskSettings` dataclass

### DIFF
--- a/annubes/tasks/task.py
+++ b/annubes/tasks/task.py
@@ -55,6 +55,8 @@ class TaskSettingsMixin:
 class Task(TaskSettingsMixin):
     """General data class for defining a task.
 
+    A task is defined by a set of trials, each of which is characterized by a sequence of inputs and expected outputs.
+
     Args:
         name: Name of the task.
         session: Configuration of the trials that can appear during a session.

--- a/annubes/tasks/task.py
+++ b/annubes/tasks/task.py
@@ -47,7 +47,7 @@ class TaskSettings:
     shuffle_trials: bool = True
     max_sequential: int | None = None
     fix_intensity: float = 0
-    fix_time: int | None = 100
+    fix_time: int = 100
     iti: int = 0
     dt: int = 20
     tau: int = 100
@@ -269,9 +269,9 @@ class Task:
         """Generate trial outputs."""
         y = np.zeros((self._ntrials, len(self.time), self.settings.n_outputs), dtype=np.float32)
         for i in range(self._ntrials):
-            if self.settings.iti is not None:
+            if self.settings.iti > 0:
                 y[i, self._phases["iti"], :] = min(self.settings.output_behavior)
-            if self.settings.fix_time is not None:
+            if self.settings.fix_time > 0:
                 y[i, self._phases["fix_time"], :] = min(self.settings.output_behavior)
 
             y[i, self._phases["input"], self._choice[i]] = max(self.settings.output_behavior)


### PR DESCRIPTION
For now, I created two distinct dataclasses, `Task` and `TaskSettings`. The first one is supposed to init all the "main" attributes (the ones the user always needs to set), while the latter is supposed to contain other attributes that generally do not need to be edited. Such attributes are accessed in `Task` from the settings attribute (which is a `TaskSettings` instance).

Main concerns/thoughts about this approach:
- Difficult to exactly determine "secondary" attributes - which ones need to be placed in `TaskSettings`. In a way, all attributes are task's settings. Maybe a different naming can help? Like `ExtraTaskSettings`?
- An alternative could be to let `Task` inherit from `TaskSettings`, so that then the user doesn't need to create a `TaskSettings` instance, but can directly use `Task` for eventually setting "secondary" attributes. I don't think this is a good approach though (`Task` is really not a `TaskSettings`), but just wanted to mention it.