### PR TITLE
refactor: improve usage of attributes and methods in `Task` class

### DIFF
--- a/annubes/task.py
+++ b/annubes/task.py
@@ -152,12 +152,7 @@ class Task(TaskSettingsMixin):
         self._modality_seq = self._build_trials_seq()
 
         # Setup phases of trial
-        self._phases = {}
-        self._phases["iti"] = np.where(self.time <= self.iti)[0]
-        self._phases["fix_time"] = np.where(
-            (self.time > self.iti) & (self.time <= self.iti + self.fix_time),
-        )[0]
-        self._phases["input"] = np.where(self.time > self.iti + self.fix_time)[0]
+        self._phases = self._setup_trial_phases()
         self._choice = (self._modality_seq != "catch").astype(np.int_)
 
         # Generate inputs and outputs
@@ -298,6 +293,16 @@ class Task(TaskSettingsMixin):
                     while i > 0 and modality_seq[i] == modality_seq[i - 1] and count >= self.max_sequential:
                         i -= 1
         return np.array(modality_seq)
+
+    def _setup_trial_phases(self) -> dict[str, NDArray]:
+        """Setup phases of trial, time-wise."""
+        phases = {}
+        phases["iti"] = np.where(self.time <= self.iti)[0]
+        phases["fix_time"] = np.where(
+            (self.time > self.iti) & (self.time <= self.iti + self.fix_time),
+        )[0]
+        phases["input"] = np.where(self.time > self.iti + self.fix_time)[0]
+        return phases
 
     def _minmaxscaler(
         self,

--- a/annubes/task.py
+++ b/annubes/task.py
@@ -146,7 +146,7 @@ class Task(TaskSettingsMixin):
 
         # Set random state
         if random_seed is None:
-            rng = np.random.default_rng()
+            rng = np.random.default_rng(random_seed)
             random_seed = rng.integers(2**32)
         self._rng = np.random.default_rng(random_seed)
         self._random_seed = random_seed

--- a/annubes/task.py
+++ b/annubes/task.py
@@ -153,7 +153,6 @@ class Task(TaskSettingsMixin):
 
         # Setup phases of trial
         self._phases = self._setup_trial_phases()
-        self._choice = (self._modality_seq != "catch").astype(np.int_)
 
         # Generate inputs and outputs
         self._inputs = self._build_trials_inputs()
@@ -358,14 +357,15 @@ class Task(TaskSettingsMixin):
     def _build_trials_outputs(self) -> NDArray[np.float32]:
         """Generate trial outputs."""
         y = np.zeros((self._ntrials, len(self.time), self.n_outputs), dtype=np.float32)
+        choice = (self._modality_seq != "catch").astype(np.int_)
         for i in range(self._ntrials):
             if self.iti > 0:
                 y[i, self._phases["iti"], :] = min(self.output_behavior)
             if self.fix_time > 0:
                 y[i, self._phases["fix_time"], :] = min(self.output_behavior)
 
-            y[i, self._phases["input"], self._choice[i]] = max(self.output_behavior)
-            y[i, self._phases["input"], 1 - self._choice[i]] = min(self.output_behavior)
+            y[i, self._phases["input"], choice[i]] = max(self.output_behavior)
+            y[i, self._phases["input"], 1 - choice[i]] = min(self.output_behavior)
 
         if self.scaling:
             y = self._minmaxscaler(y)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -35,8 +35,8 @@ def test_init_session(
 ):
     task = Task(NAME, session=session, shuffle_trials=shuffle_trials)
     assert task.name == NAME
-    assert task.session == expected_dict
-    assert isinstance(task.session, expected_type)
+    assert task._session == expected_dict
+    assert isinstance(task._session, expected_type)
 
 
 @pytest.mark.parametrize(
@@ -89,10 +89,10 @@ def test_post_init_derived_attributes(
     expected_modalities: set[str],
 ):
     task = Task(NAME, session=session, stim_time=stim_time, fix_time=fix_time, iti=iti)
-    assert task.modalities == expected_modalities
-    assert task.n_inputs == len(expected_modalities) + 1  # add the start signal
-    assert max(task.time) == stim_time + fix_time + iti
-    assert len(task.time) == int((stim_time + fix_time + iti + task.dt) / task.dt)
+    assert task._modalities == expected_modalities
+    assert task._n_inputs == len(expected_modalities) + 1  # add the start signal
+    assert max(task._time) == stim_time + fix_time + iti
+    assert len(task._time) == int((stim_time + fix_time + iti + task.dt) / task.dt)
 
 
 @pytest.mark.parametrize(
@@ -111,8 +111,8 @@ def test_build_trials_seq_distributions(session: dict, catch_prob: float):
     modality_seq = task._build_trials_seq()
     assert isinstance(modality_seq, np.ndarray)
     assert len(modality_seq) == task._ntrials
-    task.modalities.add("catch")
-    counts = {modality: np.sum(modality_seq == modality) for modality in task.modalities}
+    task._modalities.add("catch")
+    counts = {modality: np.sum(modality_seq == modality) for modality in task._modalities}
     # Assert that the counts match the expected distribution within a certain tolerance
     assert np.isclose(counts["catch"] / len(modality_seq), task.catch_prob, atol=0.1)  # within 10% tolerance
     assert np.isclose(
@@ -157,15 +157,15 @@ def test_build_trials_seq_maximum_sequential_trials():
     task._rng = np.random.default_rng(NTRIALS)
     modality_seq = task._build_trials_seq()
     # Ensure that no more than the specified maximum number of consecutive trials of the same modality occur
-    for modality in task.modalities:
+    for modality in task._modalities:
         for i in range(len(modality_seq) - task.max_sequential):
             assert np.sum(modality_seq[i : i + task.max_sequential] == modality) <= task.max_sequential
 
 
 def test_generate_trials(task: Task):
     trials = task.generate_trials()
-    assert trials["inputs"].shape == (task._ntrials, len(task.time), task.n_inputs)
-    assert trials["outputs"].shape == (task._ntrials, len(task.time), task.n_outputs)
+    assert trials["inputs"].shape == (task._ntrials, len(task._time), task._n_inputs)
+    assert trials["outputs"].shape == (task._ntrials, len(task._time), task.n_outputs)
 
 
 def test_plot_trials(task: Task):
@@ -177,7 +177,7 @@ def test_plot_trials(task: Task):
     fig = task.plot_trials(n_plots=n_plots)
     # Assert basic properties of the plot
     assert isinstance(fig, go.Figure)
-    assert len(fig["data"]) / (task.n_inputs + task.n_outputs) == n_plots  # Number of plots should match n_plots
+    assert len(fig["data"]) / (task._n_inputs + task.n_outputs) == n_plots  # Number of plots should match n_plots
     assert fig.layout.title.text == "Trials"  # Check title
     # Test with n_plots > ntrials
     n_plots = 5

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -184,12 +184,13 @@ def test_reproduce_experiment(
     trials = task.generate_trials(ntrials=ntrials, random_seed=random_seed)
     task_repro = Task(**trials["task_settings"])
     trials_repro = task_repro.generate_trials(trials["ntrials"], trials["random_seed"])
+
     # Check that the output is the same
-    assert np.array_equal(trials["modality_seq"], trials_repro["modality_seq"])
-    assert np.array_equal(trials["time"], trials_repro["time"])
+    assert task == task_repro
+    for x, y in trials.items():
+        if x != "phases":  # tested separately because it's a dict of numpy arrays
+            assert np.array_equal(y, trials_repro[x])
     assert all(np.array_equal(trials["phases"][key], trials_repro["phases"][key]) for key in trials["phases"])
-    assert np.array_equal(trials["inputs"], trials_repro["inputs"])
-    assert np.array_equal(trials["outputs"], trials_repro["outputs"])
 
 
 def test_plot_trials(task: Task):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -168,6 +168,30 @@ def test_generate_trials(task: Task):
     assert trials["outputs"].shape == (task._ntrials, len(task._time), task.n_outputs)
 
 
+@pytest.mark.parametrize(
+    ("session", "ntrials", "random_seed"),
+    [
+        ({"v": 0.5, "a": 0.5}, 20, None),
+        ({"v": 1, "a": 3}, NTRIALS, 100),
+    ],
+)
+def test_reproduce_experiment(
+    session: dict,
+    ntrials: int,
+    random_seed: int | None,
+):
+    task = Task(name=NAME, session=session)
+    trials = task.generate_trials(ntrials=ntrials, random_seed=random_seed)
+    task_repro = Task(**trials["task_settings"])
+    trials_repro = task_repro.generate_trials(trials["ntrials"], trials["random_seed"])
+    # Check that the output is the same
+    assert np.array_equal(trials["modality_seq"], trials_repro["modality_seq"])
+    assert np.array_equal(trials["time"], trials_repro["time"])
+    assert all(np.array_equal(trials["phases"][key], trials_repro["phases"][key]) for key in trials["phases"])
+    assert np.array_equal(trials["inputs"], trials_repro["inputs"])
+    assert np.array_equal(trials["outputs"], trials_repro["outputs"])
+
+
 def test_plot_trials(task: Task):
     # Generate trial data
     ntrials = 3


### PR DESCRIPTION
Main edits:
- Reordered methods in task.py so that we have special (`__post_init__`), public, and protected (one underscore) methods, specifically in this order.
- Increased modularization in `generate_trials()` by adding `_setup_trial_phases()` protected method. 
- Removed unnecessary attributes used only in one method (i.e., `_choice`).
- `generate_trials` returns now a dictionary that contains everything the user may need to 1) Exactly reproduce the experiment, so initialize again the `Task` class and call the `generate_trials` method (`"task_settings", "ntrial", "random_state"` keys), and 2) Dig/display/analyze the synthetic data generated during the current session (`"modality_seq", "time", "phases", "inputs", "outputs"` keys). The issue about the previous version was that we were saving everything into `trials`, even the protected attributes (which were repeated, e.g., there were two inputs keys -`"_inputs"` and `"inputs"`- in the old version's dictionary), and it wasn't very clear what the purpose of `trials` was looking at what was saved in it. Now I think is much clearer (see 1) and 2)) for both the user and the developer. 
- The idea behind protected attributes is that they should not be accessed directly from outside the class (even if the single underscore syntax is just a convention and not a strict rule). The user doesn't need to know how things are stored and manipulated internally. With this rationale, I made protected all attributes that are not input parameters for the constructor of the class. What is needed can be accessed from the user via the dictionary described in the bullet point above. 