### PR TITLE
feature: add range functionality to `fix_time` in `Task`

### DIFF
--- a/annubes/task.py
+++ b/annubes/task.py
@@ -176,7 +176,7 @@ class Task(TaskSettingsMixin):
         self._modality_seq = self._build_trials_seq()
 
         # Setup phases of trial
-        self._iti, self._fix_time, self._time, self._phases = self._setup_trial_phases()
+        self._fix_time, self._iti, self._time, self._phases = self._setup_trial_phases()
 
         # Generate inputs and outputs
         self._inputs = self._build_trials_inputs()
@@ -282,7 +282,7 @@ class Task(TaskSettingsMixin):
                 col=1,
             )
             fig.add_vline(
-                x=self._iti[i] + self._fix_time[i] + self.dt,
+                x=self._fix_time[i] + self.dt,
                 line_width=3,
                 line_dash="dash",
                 line_color="red",
@@ -427,15 +427,15 @@ class Task(TaskSettingsMixin):
         time = np.empty(self._ntrials, dtype=object)
         phases = np.empty(self._ntrials, dtype=object)
         for n in range(self._ntrials):
-            trial_duration = iti[n] + fix_time[n] + self.stim_time
+            trial_duration = fix_time[n] + self.stim_time + iti[n]
             time[n] = np.linspace(0, trial_duration, int((trial_duration + self.dt) / self.dt))
             phases[n] = {}
-            phases[n]["iti"] = np.where(time[n] <= iti[n])[0]
-            phases[n]["fix_time"] = np.where(
-                (time[n] > iti[n]) & (time[n] <= iti[n] + fix_time[n]),
+            phases[n]["fix_time"] = np.where(time[n] <= fix_time[n])[0]
+            phases[n]["input"] = np.where(
+                (time[n] > fix_time[n]) & (time[n] <= fix_time[n] + self.stim_time),
             )[0]
-            phases[n]["input"] = np.where(time[n] > iti[n] + fix_time[n])[0]
-        return iti, fix_time, time, phases
+            phases[n]["iti"] = np.where(time[n] >= fix_time[n] + self.stim_time)[0]
+        return fix_time, iti, time, phases
 
     def _minmaxscaler(
         self,

--- a/annubes/task.py
+++ b/annubes/task.py
@@ -340,12 +340,12 @@ class Task(TaskSettingsMixin):
 
     def _check_time_vars(self) -> None:
         strictly_positive = {
-            "stim_time": (self.stim_time, True),
-            "dt": (self.dt, True),
-            "tau": (self.tau, True),
+            "stim_time": self.stim_time,
+            "dt": self.dt,
+            "tau": self.tau,
         }
         for name, value in strictly_positive.items():
-            self._check_int_positive(name, value[0], strict=value[1])
+            self._check_int_positive(name, value, strict=True)
         self._check_range("fix_time", self.fix_time, strict=False)
         self._check_range("iti", self.iti, strict=False)
 

--- a/annubes/task.py
+++ b/annubes/task.py
@@ -326,16 +326,15 @@ class Task(TaskSettingsMixin):
             raise ValueError(msg)
 
     def _check_range(self, name: str, value: Any, strict: bool) -> None:  # noqa: ANN401
-        if isinstance(value, tuple):
+        msg = f"`{name}` must be an integer or a tuple of integers of length 2." 
+       if isinstance(value, tuple):
             if len(value) != 2:  # noqa: PLR2004
-                msg = f"`{name}` must be an integer or a tuple of integers of length 2."
                 raise ValueError(msg)
             for v in value:
                 self._check_int_positive("Each element of " + name, v, strict=strict)
         elif isinstance(value, int):
             self._check_int_positive(name, value, strict=strict)
         else:
-            msg = f"`{name}` must be an integer or a tuple of integers of length 2."
             raise TypeError(msg)
 
     def _check_time_vars(self) -> None:

--- a/annubes/task.py
+++ b/annubes/task.py
@@ -152,14 +152,7 @@ class Task(TaskSettingsMixin):
             "time", "phases", "inputs", "outputs").
         """
         # Check input parameters
-        if isinstance(ntrials, tuple):
-            if len(ntrials) != 2:  # noqa: PLR2004
-                msg = "`ntrials` must be an integer or a tuple of two integers."
-                raise ValueError(msg)
-            self._check_int_positive("ntrials", ntrials[0], strict=True)
-            self._check_int_positive("ntrials", ntrials[1], strict=True)
-        else:
-            self._check_int_positive("ntrials", ntrials, strict=True)
+        self._check_range("ntrials", ntrials, strict=True)
         if random_seed is not None:
             self._check_int_positive("random_seed", random_seed, strict=False)
 
@@ -332,12 +325,18 @@ class Task(TaskSettingsMixin):
             msg = f"`{name}` must be greater than or equal to 0."
             raise ValueError(msg)
 
-    def _check_range(self, name: str, value: Any) -> None:  # noqa: ANN401
+    def _check_range(self, name: str, value: Any, strict: bool) -> None:  # noqa: ANN401
         if isinstance(value, tuple):
+            if len(value) != 2:  # noqa: PLR2004
+                msg = f"`{name}` must be an integer or a tuple of integers of length 2."
+                raise ValueError(msg)
             for v in value:
-                self._check_int_positive(name, v, strict=False)
+                self._check_int_positive("Each element of " + name, v, strict=strict)
+        elif isinstance(value, int):
+            self._check_int_positive(name, value, strict=strict)
         else:
-            self._check_int_positive(name, value, strict=False)
+            msg = f"`{name}` must be an integer or a tuple of integers of length 2."
+            raise TypeError(msg)
 
     def _check_time_vars(self) -> None:
         strictly_positive = {
@@ -347,8 +346,8 @@ class Task(TaskSettingsMixin):
         }
         for name, value in strictly_positive.items():
             self._check_int_positive(name, value[0], strict=value[1])
-        self._check_range("fix_time", self.fix_time)
-        self._check_range("iti", self.iti)
+        self._check_range("fix_time", self.fix_time, strict=False)
+        self._check_range("iti", self.iti, strict=False)
 
     def _check_bool(self, name: str, value: Any) -> None:  # noqa: ANN401
         if not isinstance(value, bool):

--- a/annubes/task.py
+++ b/annubes/task.py
@@ -326,8 +326,8 @@ class Task(TaskSettingsMixin):
             raise ValueError(msg)
 
     def _check_range(self, name: str, value: Any, strict: bool) -> None:  # noqa: ANN401
-        msg = f"`{name}` must be an integer or a tuple of integers of length 2." 
-       if isinstance(value, tuple):
+        msg = f"`{name}` must be an integer or a tuple of integers of length 2."
+        if isinstance(value, tuple):
             if len(value) != 2:  # noqa: PLR2004
                 raise ValueError(msg)
             for v in value:

--- a/annubes/task.py
+++ b/annubes/task.py
@@ -21,7 +21,9 @@ class TaskSettingsMixin:
     Args:
         fix_intensity: Intensity of input signal during fixation.
             Defaults to 0.
-        fix_time: Fixation time in ms. Note that the duration of each input and output signal is increased by this time.
+        fix_time: Fixation time in ms. If a tuple is given, it is
+            interpreted as an interval of possible values, and for each trial the value will be randomly picked from it.
+            Note that the duration of each input and output signal is increased by this time.
             Defaults to 100.
         iti: Inter-trial interval, or time window between sequential trials, in ms. If a tuple is given, it is
             interpreted as an interval of possible values, and for each trial the value will be randomly picked from it.
@@ -43,7 +45,7 @@ class TaskSettingsMixin:
     """
 
     fix_intensity: float = 0
-    fix_time: int = 100
+    fix_time: int | tuple[int, int] = 100
     iti: int | tuple[int, int] = 0
     dt: int = 20
     tau: int = 100
@@ -340,10 +342,15 @@ class Task(TaskSettingsMixin):
             "stim_time": (self.stim_time, True),
             "dt": (self.dt, True),
             "tau": (self.tau, True),
-            "fix_time": (self.fix_time, False),
         }
         for name, value in strictly_positive.items():
             self._check_int_positive(name, value[0], strict=value[1])
+        # Check fix_time and iti
+        if isinstance(self.fix_time, tuple):
+            for fix_time in self.fix_time:
+                self._check_int_positive("fix_time", fix_time, strict=False)
+        else:
+            self._check_int_positive("fix_time", self.fix_time, strict=False)
         if isinstance(self.iti, tuple):
             for iti in self.iti:
                 self._check_int_positive("iti", iti, strict=False)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -306,20 +306,22 @@ def test_setup_trial_phases(stim_time: int, fix_time: int, iti: int | tuple[int,
     # phases
     assert task._phases.shape == (NTRIALS,)
     assert all(
-        len(task._phases[n_trial]["iti"]) == len(np.where(task._time[n_trial] <= task._iti[n_trial])[0])
+        len(task._phases[n_trial]["fix_time"]) == len(np.where(task._time[n_trial] <= task._fix_time[n_trial])[0])
         for n_trial in trial_indices
     )
     assert all(
-        len(task._phases[n_trial]["fix_time"])
+        len(task._phases[n_trial]["input"])
         == len(
             np.where(
-                (task._time[n_trial] > task._iti[n_trial]) & (task._time[n_trial] <= task._iti[n_trial] + fix_time),
+                (task._time[n_trial] > task._fix_time[n_trial])
+                & (task._time[n_trial] <= task._fix_time[n_trial] + stim_time),
             )[0],
         )
         for n_trial in trial_indices
     )
     assert all(
-        len(task._phases[n_trial]["input"]) == len(np.where(task._time[n_trial] > task._iti[n_trial] + fix_time)[0])
+        len(task._phases[n_trial]["iti"])
+        == len(np.where(task._time[n_trial] >= task._fix_time[n_trial] + stim_time)[0])
         for n_trial in trial_indices
     )
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -90,6 +90,8 @@ def test_post_init_check_float_positive(
         pytest.param(1000, 20, 100, -1, 0, marks=pytest.mark.xfail(raises=ValueError)),
         pytest.param(1000, 20, 100, 100, "a", marks=pytest.mark.xfail(raises=TypeError)),
         pytest.param(1000, 20, 100, 100, -1, marks=pytest.mark.xfail(raises=ValueError)),
+        pytest.param(1000, 20, 100, ("a", 0), 0, marks=pytest.mark.xfail(raises=TypeError)),
+        pytest.param(1000, 20, 100, (-1, 0), 0, marks=pytest.mark.xfail(raises=ValueError)),
         pytest.param(1000, 20, 100, 100, ("a", 0), marks=pytest.mark.xfail(raises=TypeError)),
         pytest.param(1000, 20, 100, 100, (-1, 0), marks=pytest.mark.xfail(raises=ValueError)),
     ],
@@ -283,9 +285,9 @@ def test_build_trials_seq_maximum_sequential_trials():
 
 @pytest.mark.parametrize(
     ("stim_time", "fix_time", "iti"),
-    [(1000, 100, 0), (1000, 100, (300, 500))],
+    [(1000, 100, 0), (1000, 100, (300, 500)), (1000, (3000, 5000), 0)],
 )
-def test_setup_trial_phases(stim_time: int, fix_time: int, iti: int | tuple[int, int]):
+def test_setup_trial_phases(stim_time: int, fix_time: int | tuple[int, int], iti: int | tuple[int, int]):
     task = Task(NAME, stim_time=stim_time, fix_time=fix_time, iti=iti)
     _ = task.generate_trials(ntrials=NTRIALS)
     trial_indices = range(NTRIALS)
@@ -299,10 +301,13 @@ def test_setup_trial_phases(stim_time: int, fix_time: int, iti: int | tuple[int,
     # time
     assert task._time.shape == (NTRIALS,)
     assert all(
-        len(task._time[n_trial]) == int(stim_time + fix_time + task._iti[n_trial] + task.dt) / task.dt
+        len(task._time[n_trial]) == int(stim_time + task._fix_time[n_trial] + task._iti[n_trial] + task.dt) / task.dt
         for n_trial in trial_indices
     )
-    assert all(max(task._time[n_trial]) == stim_time + fix_time + task._iti[n_trial] for n_trial in trial_indices)
+    assert all(
+        max(task._time[n_trial]) == stim_time + task._fix_time[n_trial] + task._iti[n_trial]
+        for n_trial in trial_indices
+    )
     # phases
     assert task._phases.shape == (NTRIALS,)
     assert all(


### PR DESCRIPTION
- added range functionality to `fix_time`
- adjusted times order in the signals and fix the tests 
- wrapped together functions for tuples
- added tests for `fix_time` as a range