### PR TITLE
refactor: `_build_trials_seq`

### DIFF
--- a/annubes/task.py
+++ b/annubes/task.py
@@ -111,12 +111,12 @@ class Task(TaskSettingsMixin):
             self._check_float_positive("output_behavior", intensity)
         self._check_float_positive("noise_std", self.noise_std)
         self._check_time_vars()
+        self._check_int_positive("n_outputs", self.n_outputs, strict=True)
+        self._check_bool("scaling", self.scaling)
+        self._check_bool("shuffle_trials", self.shuffle_trials)
         if self.max_sequential:
             self._check_int_positive("max_sequential", self.max_sequential, strict=True)
         self._check_int_positive("max_draws", self.max_draws, strict=True)
-        self._check_int_positive("n_outputs", self.n_outputs, strict=True)
-        self._check_bool("shuffle_trials", self.shuffle_trials)
-        self._check_bool("scaling", self.scaling)
 
         # store raw inputs
         self._task_settings = vars(self).copy()
@@ -129,6 +129,7 @@ class Task(TaskSettingsMixin):
         # Derived attributes
         self._modalities = set(dict.fromkeys(char for string in self._session for char in string))
         self._n_inputs = len(self._modalities) + 1  # includes start cue
+        self._constrained_shuffle = self.shuffle_trials and self.max_sequential
 
     def generate_trials(
         self,
@@ -357,7 +358,7 @@ class Task(TaskSettingsMixin):
         options = list(self._session.keys())
         probs = list(self._session.values())
 
-        if not (self.shuffle_trials and max_seq):
+        if not self._constrained_shuffle:
             n_samples = self._rng.multinomial(self._ntrials, probs)  # Random ratio of samples based on probs
 
             modality_seq = (  # Create list with expected number of entries for each option (in order and unshuffled)

--- a/annubes/task.py
+++ b/annubes/task.py
@@ -356,7 +356,6 @@ class Task(TaskSettingsMixin):
         # Extract options and probs from the dictionary
         options = list(self._session.keys())
         probs = list(self._session.values())
-        max_seq = self.max_sequential
 
         if not (self.shuffle_trials and max_seq):
             n_samples = self._rng.multinomial(self._ntrials, probs)  # Random ratio of samples based on probs
@@ -375,7 +374,7 @@ class Task(TaskSettingsMixin):
                 self._rng.shuffle(modality_seq)
 
         else:  # if shuffle and max_seq
-            too_many_reps = max_seq + 1
+            too_many_reps = self.max_sequential + 1
             modality_seq = []
             n_failed_max_seq = 0
 
@@ -396,7 +395,7 @@ class Task(TaskSettingsMixin):
             if n_failed_max_seq:
                 msg = (
                     f"{n_failed_max_seq} occurrences (in {self._ntrials} cases) of failure to enforce the "
-                    f"`max_sequential` condition of {max_seq} repetions after {self.max_draws} attempts. "
+                    f"`max_sequential` condition of {self.max_sequential} repetions after {self.max_draws} attempts. "
                     f"final sequence is: {'-'.join(modality_seq)}"
                 )
                 warnings.warn(msg, stacklevel=2)

--- a/annubes/task.py
+++ b/annubes/task.py
@@ -122,6 +122,7 @@ class Task(TaskSettingsMixin):
         self._task_settings = vars(self).copy()
 
         # make self._session adhere to expected format
+        self._session = {i: self.session[i] / sum(self.session.values()) for i in self.session}
         if not self.shuffle_trials:
             self._session = OrderedDict(self._session)
 

--- a/annubes/task.py
+++ b/annubes/task.py
@@ -373,8 +373,8 @@ class Task(TaskSettingsMixin):
 
             for i in range(self._ntrials):
                 if (  # not reached maximum number of consecutive trials
-                    i < self.max_sequential
-                    or [modality_seq[-1]] * self.max_sequential != modality_seq[-self.max_sequential :]
+                    i < self.max_sequential  # type: ignore[operator]
+                    or [modality_seq[-1]] * self.max_sequential != modality_seq[-self.max_sequential :]  # type: ignore[operator]
                 ):
                     modality_seq.append(self._rng.choice(adjusted_options, p=adjusted_probs))
                 elif modality_seq[-1] == "X":  # reached maximum number of consecutive catches

--- a/annubes/task.py
+++ b/annubes/task.py
@@ -78,16 +78,16 @@ class Task(TaskSettingsMixin):
         shuffle_trials: If True (default), trial order will be randomized. If False, all trials corresponding to one
             modality (e.g. visual) are run before any trial of the next modality (e.g. auditory) starts, in the order
             defined in `session` (with randomly interspersed catch trials).
-        max_sequential: If `shuffle_trials` is True, sets the maximum number of sequential trials. Note that exceptions
-            can exist (see description for `max_redraws` below for details).
+        max_sequential: If `shuffle_trials` is True, sets the maximum number of sequential trials of the same modality.
+            Note that exceptions can exist (see description for `max_draws` below for details).
             Defaults to None (no maximum).
         max_draws: Only used if `shuffle_trials` is True and `max_sequential` is not None. Sets the maximum number of
             times an attempt is made to select a random trial that does not break the `max_sequential` setting above.
-            Once this many draws were made, a warning is given and the selection is used nonetheless.
+            Once this many draws are made, a warning is given and the selection is used nonetheless.
             Defaults to 20.
             Note that this is mainly relevant when `session` or `catch_prob` is set such that the odds of repetition are
-                very high, and that in this case, a high value for `max_draws` will exponentially slow down the process
-                of creating a trial order.
+            very high, and that in this case, a high value for `max_draws` will exponentially slow down the process of
+            creating a trial order.
     """
 
     name: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,7 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python :: 3.11",
 ]
-dependencies = [
-    "numpy >= 1.26.2",
-    "ruff >= 0.3.0", 
-    "plotly",
-    "tqdm"]
+dependencies = ["numpy >= 1.26.2", "plotly", "tqdm"]
 description = "ANNUBeS: training Artificial Neural Networks to Uncover Behavioral Strategies in neuroscience"
 keywords = ["neuroscience", "neural networks"]
 license = { file = "LICENSE" }
@@ -37,7 +33,7 @@ dev = [
     "build",
     "bump2version",
     # formatting and linting
-    "ruff",
+    "ruff >= 0.3.0",
     # testing
     "pytest",
     "pytest-cov",
@@ -50,7 +46,7 @@ dev = [
     "mkdocs-exclude",
     "mkdocs-redirects",
     "mkdocstrings-python",
-    "mike"
+    "mike",
 ]
 publishing = ["build", "twine", "wheel"]
 
@@ -80,70 +76,4 @@ python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
-
-[tool.ruff]
-line-length = 120
-
-[tool.ruff.lint]
-select = ["ALL"]
-ignore = [
-    # Unwanted (potentially)
-    "FBT",    # Using boolean arguments
-    "ANN101", # Missing type annotation for `self` in method
-    "ANN102", # Missing type annotation for `cls` in classmethod
-    "ANN204", # Missing return type annotation for special (dunder) method
-    "S105",   # Possible hardcoded password
-    "S311",   # insecure random generators
-    "PT011",  # pytest-raises-too-broad
-    "TD",     # TODOs
-    "FIX002", # Resolve TODOs
-    # We may choose to ignore these in the future if they are counterproductive
-    # "B028",   # No explicit `stacklevel` keyword argument found in warning
-    # "SIM108", # Use ternary operator
-    # Unneeded docstrings
-    "D100", # Missing module docstring
-    "D104", # Missing public package docstring
-    "D105", # Missing docstring in magic method
-    "D107", # Missing docstring in `__init__`
-    # Rules irrelevant to the Google style
-    "D203", # 1 blank line required before class docstring
-    "D204",
-    "D212", # Multi-line docstring summary should start at the first line
-    "D213", # Multi-line docstring summary should start at the second line
-    "D215",
-    "D400",
-    "D401",
-    "D404", # First word of the docstring should not be This
-    "D406",
-    "D407",
-    "D408",
-    "D409",
-    "D413",
-]
-
-# Autofix settings
-fixable = ["ALL"]
-unfixable = ["F401"] # unused imports (should not disappear while editing)
-extend-safe-fixes = [
-    "D415",   # First line should end with a period, question mark, or exclamation point
-    "D300",   # Use triple double quotes `"""`
-    "D200",   # One-line docstring should fit on one line
-    "TCH",    # Format type checking only imports
-    "ISC001", # Implicitly concatenated strings on a single line
-    "EM",     # Exception message variables
-    "RUF013", # Implicit Optional
-    "B006",   # Mutable default argument
-]
-
-isort.known-first-party = ["annubes"]
-
-[tool.ruff.lint.per-file-ignores]
-"*.ipynb" = ["ERA001"] # Commented out code
-"tests/*" = [
-    "S101",   # Use of `assert` detected
-    "ANN201", # Missing return type
-    "D103",   # Missing function docstring
-    "SLF001", # Private member access
-    "ANN401", # Function arguments annotated with too generic `Any` type
-]
-"docs/*" = ["ALL"]
+show_error_codes = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,66 @@
+target-version = "py311"
+line-length = 120
+
+[lint]
+select = ["ALL"]
+ignore = [
+    # Unwanted (potentially)
+    "FBT",    # Using boolean arguments
+    "ANN101", # Missing type annotation for `self` in method
+    "ANN102", # Missing type annotation for `cls` in classmethod
+    "ANN204", # Missing return type annotation for special (dunder) method
+    "S105",   # Possible hardcoded password
+    "S311",   # insecure random generators
+    "PT011",  # pytest-raises-too-broad
+    "TD",     # TODOs
+    "FIX002", # Resolve TODOs
+    # We may choose to ignore these in the future if they are counterproductive
+    # "B028",   # No explicit `stacklevel` keyword argument found in warning
+    # "SIM108", # Use ternary operator
+    # Unneeded docstrings
+    "D100", # Missing module docstring
+    "D104", # Missing public package docstring
+    "D105", # Missing docstring in magic method
+    "D107", # Missing docstring in `__init__`
+    # Rules irrelevant to the Google style
+    "D203", # 1 blank line required before class docstring
+    "D204",
+    "D212", # Multi-line docstring summary should start at the first line
+    "D213", # Multi-line docstring summary should start at the second line
+    "D215",
+    "D400",
+    "D401",
+    "D404", # First word of the docstring should not be This
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+
+# Autofix settings
+fixable = ["ALL"]
+unfixable = ["F401"] # unused imports (should not disappear while editing)
+extend-safe-fixes = [
+    "D415",   # First line should end with a period, question mark, or exclamation point
+    "D300",   # Use triple double quotes `"""`
+    "D200",   # One-line docstring should fit on one line
+    "TCH",    # Format type checking only imports
+    "ISC001", # Implicitly concatenated strings on a single line
+    "EM",     # Exception message variables
+    "RUF013", # Implicit Optional
+    "B006",   # Mutable default argument
+]
+
+isort.known-first-party = ["annubes"]
+
+[lint.per-file-ignores]
+"*.ipynb" = ["ERA001"] # Commented out code
+"tests/*" = [
+    "S101",   # Use of `assert` detected
+    "ANN201", # Missing return type
+    "D103",   # Missing function docstring
+    "SLF001", # Private member access
+    "ANN401", # Function arguments annotated with too generic `Any` type
+]
+"docs/*" = ["ALL"]

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -242,12 +242,12 @@ def test_build_trials_seq_distributions(session: dict, catch_prob: float):
     # Assert that the counts match the expected distribution within a certain tolerance
     ratios = {
         modality: np.sum(task._modality_seq == modality) / len(task._modality_seq)
-        for modality in [*task._modalities, "catch"]
+        for modality in [*task._modalities, "X"]
     }
     expected_ratios = {
         "v": task.session["v"] - task.catch_prob * task.session["v"],
         "a": task.session["a"] - task.catch_prob * task.session["a"],
-        "catch": task.catch_prob,
+        "X": task.catch_prob,
     }
     tolerance = 0.2
 
@@ -259,7 +259,7 @@ def test_build_trials_seq_distributions(session: dict, catch_prob: float):
         ), f"Actual difference for {modality}: {round(abs(actual_ratio - expected_ratios[modality]), 3)}"
 
     # Assert that total counts match the expected number exactly
-    assert np.isclose(ratios["a"] + ratios["v"] + ratios["catch"], 1.0)  # avoid floating point errors
+    assert np.isclose(ratios["a"] + ratios["v"] + ratios["X"], 1.0)  # avoid floating point errors
     assert len(task._modality_seq) == task._ntrials
 
 
@@ -298,12 +298,10 @@ def test_build_trials_seq_maximum_sequential_trials(session: dict[str, float], c
     _ = task.generate_trials(ntrials=NTRIALS)
 
     # Ensure that no more than the specified maximum number of consecutive trials of the same modality occur
-    sequence_string = "".join(task._modality_seq).replace("catch", "X")
+    sequence_string = "".join(task._modality_seq)
     too_many = task.max_sequential + 1
     for mod in set(sequence_string):
-        assert (
-            mod * (too_many) not in sequence_string
-        ), f'{mod.replace("X", "catch")} was detected too many times (seed: {task._random_seed})'
+        assert mod * (too_many) not in sequence_string, f"{mod} was detected too many times (seed: {task._random_seed})"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -251,15 +251,15 @@ def test_build_trials_seq_distributions(session: dict, catch_prob: float):
     }
     tolerance = 0.2
 
-    for modularity, actual_ratio in ratios.items():
+    for modality, actual_ratio in ratios.items():
         assert np.isclose(
             actual_ratio,
-            expected_ratios[modularity],
+            expected_ratios[modality],
             atol=tolerance,
-        ), f"Actual difference for {modularity}: {round(abs(actual_ratio[0] - expected_ratios[modularity]), 3)}"
+        ), f"Actual difference for {modality}: {round(abs(actual_ratio - expected_ratios[modality]), 3)}"
 
     # Assert that total counts match the expected number exactly
-    assert ratios["a"] + ratios["v"] + ratios["catch"] == 1
+    assert np.isclose(ratios["a"] + ratios["v"] + ratios["catch"], 1.0)  # avoid floating point errors
     assert len(task._modality_seq) == task._ntrials
 
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -281,9 +281,20 @@ def test_build_trials_seq_shuffling():
     assert keys[0] not in task_not_shuffled._modality_seq[first_occurrence:]
 
 
-def test_build_trials_seq_maximum_sequential_trials():
+@pytest.mark.parametrize(
+    ("session", "catch_prob", "max_sequential"),
+    [
+        ({"v": 0.5, "a": 0.5}, 0.5, 4),
+        ({"v": 0.5, "a": 0.5}, 0.5, 1),
+        ({"v": 0.8, "a": 0.2}, 0.1, 4),
+        ({"v": 0.5, "a": 0.5}, 0.9, 4),
+        ({"v": 0.5, "a": 0.5}, 0.9, 1),
+        pytest.param({"v": 0.5, "a": 0.5}, 0.5, 0.5, marks=pytest.mark.xfail(raises=TypeError)),
+    ],
+)
+def test_build_trials_seq_maximum_sequential_trials(session: dict[str, float], catch_prob: float, max_sequential: int):
     # Create a Task instance with shuffling enabled and a maximum sequential trial constraint
-    task = Task(name=NAME, max_sequential=4)
+    task = Task(name=NAME, session=session, catch_prob=catch_prob, max_sequential=max_sequential)
     _ = task.generate_trials(ntrials=NTRIALS)
 
     # Ensure that no more than the specified maximum number of consecutive trials of the same modality occur

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -272,16 +272,13 @@ def test_build_trials_seq_shuffling():
 
     assert task_shuffled._modality_seq.shape == task_not_shuffled._modality_seq.shape
 
+    # check that shuffled and unshuffled are different
+    assert not np.array_equal(task_shuffled._modality_seq, task_not_shuffled._modality_seq)
+
+    # check that there is no "v" after any "a", which would mean that the list is shuffled
     keys = list(task_shuffled._session.keys())
     first_occurrence = list(task_not_shuffled._modality_seq).index(keys[1])
-    assert (
-        keys[0] not in task_not_shuffled._modality_seq[first_occurrence:]
-    ), "unshuffled _modality_seq appears shuffled"
-
-    assert not np.array_equal(
-        task_shuffled._modality_seq,
-        task_not_shuffled._modality_seq,
-    ), "shuffled _modality_seq == unshuffled _modality_seq"
+    assert keys[0] not in task_not_shuffled._modality_seq[first_occurrence:]
 
 
 def test_build_trials_seq_maximum_sequential_trials():

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -284,10 +284,14 @@ def test_build_trials_seq_maximum_sequential_trials():
     # Create a Task instance with shuffling enabled and a maximum sequential trial constraint
     task = Task(name=NAME, max_sequential=4)
     _ = task.generate_trials(ntrials=NTRIALS)
+
     # Ensure that no more than the specified maximum number of consecutive trials of the same modality occur
-    for modality in task._modalities:
-        for i in range(len(task._modality_seq) - task.max_sequential):
-            assert np.sum(task._modality_seq[i : i + task.max_sequential] == modality) <= task.max_sequential
+    sequence_string = "".join(task._modality_seq).replace("catch", "X")
+    too_many = task.max_sequential + 1
+    for mod in set(sequence_string):
+        assert (
+            mod * (too_many) not in sequence_string
+        ), f'{mod.replace("X", "catch")} was detected too many times (seed: {task._random_seed})'
 
 
 @pytest.mark.parametrize(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -171,7 +171,7 @@ def test_post_init_session(
     task = Task(NAME, session=session, shuffle_trials=shuffle_trials)
     assert task.name == NAME
     assert task._session == expected_dict
-    assert isinstance(task._session, expected_type)  # type: ignore # noqa: PGH003
+    assert isinstance(task._session, expected_type)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(
@@ -185,7 +185,7 @@ def test_post_init_session(
     ],
 )
 def test_post_init_catch_prob(catch_prob: float | None, expected: float | None):
-    task = Task(NAME, catch_prob=catch_prob)  # type: ignore # noqa: PGH003
+    task = Task(NAME, catch_prob=catch_prob)  # type: ignore[arg-type]
     assert task.name == NAME
     assert task.catch_prob == expected
 
@@ -299,7 +299,7 @@ def test_build_trials_seq_maximum_sequential_trials(session: dict[str, float], c
 
     # Ensure that no more than the specified maximum number of consecutive trials of the same modality occur
     sequence_string = "".join(task._modality_seq)
-    too_many = task.max_sequential + 1
+    too_many = task.max_sequential + 1  # type: ignore[operator]
     for mod in set(sequence_string):
         assert mod * (too_many) not in sequence_string, f"{mod} was detected too many times (seed: {task._random_seed})"
 


### PR DESCRIPTION
fix: #29

- refactor: `_build_trials_seq` without `max_sequential` 
- refactor: tests associated to above
- test: fixed bug in `test_build_trials_seq_maximum_sequential_trials`
- fix: max constrained shuffle
- docs: update `Task` docstring and code comments
- refactor: sum _session values to 1