### PR TITLE
fix: values assignment for the input signals

### DIFF
--- a/annubes/task.py
+++ b/annubes/task.py
@@ -470,8 +470,12 @@ class Task(TaskSettingsMixin):
                 (len(self._time[n]), self._n_inputs),
                 dtype=np.float32,
             )
-            for idx, _ in enumerate(self._modalities):
-                value = self._rng.choice(self.stim_intensities, 1) if self._modality_seq[n] != "X" else 0
+            for idx, mod in enumerate(self._modalities):
+                value = (
+                    self._rng.choice(self.stim_intensities, 1)
+                    if (self._modality_seq[n] != "X" and self._modality_seq[n] == mod)
+                    else 0
+                )
                 x[n][self._phases[n]["fix_time"], idx] = self.fix_intensity
                 x[n][self._phases[n]["input"], idx] = value
             x[n][self._phases[n]["input"], self._n_inputs - 1] = 1  # start cue

--- a/annubes/task.py
+++ b/annubes/task.py
@@ -471,13 +471,9 @@ class Task(TaskSettingsMixin):
                 dtype=np.float32,
             )
             for idx, mod in enumerate(self._modalities):
-                value = (
-                    self._rng.choice(self.stim_intensities, 1)
-                    if (self._modality_seq[n] != "X" and self._modality_seq[n] == mod)
-                    else 0
-                )
+                if self._modality_seq[n] != "X" and self._modality_seq[n] == mod:
+                    x[n][self._phases[n]["input"], idx] = self._rng.choice(self.stim_intensities, 1)
                 x[n][self._phases[n]["fix_time"], idx] = self.fix_intensity
-                x[n][self._phases[n]["input"], idx] = value
             x[n][self._phases[n]["input"], self._n_inputs - 1] = 1  # start cue
             # add noise
             x[n] += noise_factor * self._rng.normal(loc=0, scale=1, size=x[n].shape)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -550,3 +550,19 @@ def test_plot_trials(task: Task):
         == f"Number of plots requested ({n_plots}) exceeds number of trials ({ntrials}). Will plot all trials."
     )
     assert warning.category == UserWarning
+
+
+def test_intensity_trials():
+    task = Task(name=NAME, session=SESSION, stim_intensities=STIM_INTENSITIES, scaling=SCALING)
+    trials = task.generate_trials(ntrials=NTRIALS)
+    high_val = 0.6  # for a signal to be considered high
+    low_val = 0.3  # for a signal to be considered low
+    for n in range(NTRIALS):
+        for idx, mod in enumerate(task._modalities):
+            assert (
+                (trials["inputs"][n][task._phases[n]["input"], idx] > high_val).all()
+                if trials["modality_seq"][n] == mod  # check if the signal is high if the modality is the current one
+                else (
+                    trials["inputs"][n][task._phases[n]["input"], idx] < low_val
+                ).all()  # check if the signal is low otherwise
+            )


### PR DESCRIPTION
I just noticed that PR #40 broke the assignment of the value for the input signals. In particular, the input signal needs to be set to 0 both if the modality is 'X' and if the modality is not the same as the one indicated in the sequence (e.g., the sequence has 'v', but the input signal we're building up is 'a').